### PR TITLE
config: Change tab size to 2

### DIFF
--- a/languages/blueprint/config.toml
+++ b/languages/blueprint/config.toml
@@ -3,7 +3,7 @@ grammar = "blueprint"
 path_suffixes = ["blp"]
 line_comments = ["// "]
 autoclose_before = ";:.,=)}]"
-tab_size = 4
+tab_size = 2
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
This is what blueprint-compiler uses by default.