### PR TITLE
Add brackets.scm query

### DIFF
--- a/languages/blueprint/brackets.scm
+++ b/languages/blueprint/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+(("'" @open "'" @close) (#set! rainbow.exclude))
+(("\"" @open "\"" @close) (#set! rainbow.exclude))


### PR DESCRIPTION
Zed has rainbow brackets now and uses brackets.scm query to implement this feature. https://zed.dev/blog/rainbow-brackets